### PR TITLE
Add maps_layouts support

### DIFF
--- a/OrionUO/Globals.cpp
+++ b/OrionUO/Globals.cpp
@@ -39,6 +39,7 @@ GLuint ShaderColorTable = 0;
 GLuint g_ShaderDrawMode = 0;
 
 string g_Language = "ENU";
+string g_MapsLayouts;
 
 GAME_STATE g_GameState = GS_MAIN;
 

--- a/OrionUO/Globals.h
+++ b/OrionUO/Globals.h
@@ -104,6 +104,7 @@ extern GLuint ShaderColorTable;
 extern GLuint g_ShaderDrawMode;
 
 extern string g_Language;
+extern string g_MapsLayouts;
 
 extern GAME_STATE g_GameState;
 

--- a/OrionUO/OrionUO.cpp
+++ b/OrionUO/OrionUO.cpp
@@ -16,6 +16,7 @@
 #include "Wisp/WispGlobal.h"
 #include "FileSystem.h"
 #include "Crypt/CryptEntry.h"
+#include <sstream>
 
 #if defined(ORION_LINUX)
 #define CDECL
@@ -307,7 +308,10 @@ bool COrion::Install()
 
     if (!g_FileManager.Load())
     {
-        auto errMsg = string("Error loading a memmapped file. Please check the log for more info.\nUsing UO search path: ") + StringFromPath(g_App.m_UOPath);
+        auto errMsg =
+            string(
+                "Error loading a memmapped file. Please check the log for more info.\nUsing UO search path: ") +
+            StringFromPath(g_App.m_UOPath);
         g_OrionWindow.ShowMessage(errMsg, "FileManager::Load");
         return false;
     }
@@ -1088,6 +1092,25 @@ bool COrion::LoadClientConfig()
 
             g_MapBlockSize[i].Width = g_MapSize[i].Width / 8;
             g_MapBlockSize[i].Height = g_MapSize[i].Height / 8;
+        }
+
+        if (!g_MapsLayouts.empty())
+        {
+            string token;
+            stringstream ss(g_MapsLayouts);
+            int idx = 0;
+            while (std::getline(ss, token, ';') && idx < MAX_MAPS_COUNT)
+            {
+                int width = 0, height = 0;
+                if (sscanf(token.c_str(), "%d,%d", &width, &height) == 2)
+                {
+                    g_MapSize[idx].Width = width;
+                    g_MapSize[idx].Height = height;
+                    g_MapBlockSize[idx].Width = width / 8;
+                    g_MapBlockSize[idx].Height = height / 8;
+                }
+                ++idx;
+            }
         }
 
         g_CharacterList.ClientFlag = file.ReadInt8();
@@ -3594,8 +3617,8 @@ uint64_t COrion::CreateHash(const char *s)
 void COrion::LoadIndexFiles()
 {
     PART_IDX_BLOCK LandArtPtr = (PART_IDX_BLOCK)g_FileManager.m_ArtIdx.Start;
-    PART_IDX_BLOCK StaticArtPtr = (PART_IDX_BLOCK)(
-        (size_t)g_FileManager.m_ArtIdx.Start + (m_LandData.size() * sizeof(ART_IDX_BLOCK)));
+    PART_IDX_BLOCK StaticArtPtr =
+        (PART_IDX_BLOCK)((size_t)g_FileManager.m_ArtIdx.Start + (m_LandData.size() * sizeof(ART_IDX_BLOCK)));
     PGUMP_IDX_BLOCK GumpArtPtr = (PGUMP_IDX_BLOCK)g_FileManager.m_GumpIdx.Start;
     PTEXTURE_IDX_BLOCK TexturePtr = (PTEXTURE_IDX_BLOCK)g_FileManager.m_TextureIdx.Start;
     PMULTI_IDX_BLOCK MultiPtr = (PMULTI_IDX_BLOCK)g_FileManager.m_MultiIdx.Start;

--- a/OrionUO/ScreenStages/MainScreen.cpp
+++ b/OrionUO/ScreenStages/MainScreen.cpp
@@ -245,7 +245,7 @@ int CMainScreen::GetConfigKeyCode(const string &key)
 
     static const string m_Keys[keyCount] = { "acctid",    "acctpassword",  "rememberacctpw",
                                              "autologin", "smoothmonitor", "theabyss",
-                                             "asmut",     "custompath" };
+                                             "asmut",     "custompath",    "maps_layouts" };
 
     string str = ToLowerA(key);
     int result = 0;
@@ -282,6 +282,15 @@ void CMainScreen::LoadCustomPath()
                 case MSCC_CUSTOM_PATH:
                 {
                     g_App.m_UOPath = ToPath(strings[1]);
+                    break;
+                }
+                case MSCC_MAPS_LAYOUTS:
+                {
+                    string layouts = file.RawLine;
+                    size_t pos = layouts.find_first_of('=');
+                    if (pos != string::npos)
+                        g_MapsLayouts = layouts.substr(pos + 1);
+                    break;
                 }
             }
         }
@@ -383,6 +392,15 @@ void CMainScreen::LoadGlobalConfig()
 
                     break;
                 }
+                case MSCC_MAPS_LAYOUTS:
+                {
+                    string layouts = file.RawLine;
+                    size_t pos = layouts.find_first_of('=');
+                    if (pos != string::npos)
+                        g_MapsLayouts = layouts.substr(pos + 1);
+
+                    break;
+                }
                 default:
                     break;
             }
@@ -438,6 +456,11 @@ void CMainScreen::SaveGlobalConfig()
     if (g_App.m_UOPath != g_App.m_ExePath)
     {
         sprintf_s(buf, "CustomPath=%s\n", CStringFromPath(g_App.m_UOPath));
+        fputs(buf, uo_cfg);
+    }
+    if (!g_MapsLayouts.empty())
+    {
+        sprintf_s(buf, "Maps_Layouts=%s\n", g_MapsLayouts.c_str());
         fputs(buf, uo_cfg);
     }
     fs_close(uo_cfg);

--- a/OrionUO/ScreenStages/MainScreen.h
+++ b/OrionUO/ScreenStages/MainScreen.h
@@ -23,6 +23,7 @@ private:
         MSCC_THE_ABYSS,
         MSCC_ASMUT,
         MSCC_CUSTOM_PATH,
+        MSCC_MAPS_LAYOUTS,
         MSCC_COUNT,
     };
 


### PR DESCRIPTION
## Summary
- add `g_MapsLayouts` global for custom map sizes
- parse `maps_layouts` from `uo_debug.cfg`
- allow saving `Maps_Layouts` in config
- apply custom map sizes when loading client config

## Testing
- `clang-format-14 -i OrionUO/OrionUO.cpp OrionUO/Globals.cpp OrionUO/Globals.h OrionUO/ScreenStages/MainScreen.cpp OrionUO/ScreenStages/MainScreen.h`
- `cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release` *(fails: Could NOT find SDL2_image)*

------
https://chatgpt.com/codex/tasks/task_e_6855a0caf3c0832f9c0218987e0b7438