### PR TITLE
Enable maps layouts via CLI

### DIFF
--- a/OrionUO/OrionMain.cpp
+++ b/OrionUO/OrionMain.cpp
@@ -83,6 +83,10 @@ int main(int argc, char **argv)
             g_isHeadless = true;
         else if (!strcmp(argv[i], "--nocrypt"))
             g_EncryptionType = ET_NOCRYPT;
+        else if (!strncmp(argv[i], "--maps-layouts=", 15))
+            g_MapsLayouts = std::string(argv[i] + 15);
+        else if (!strcmp(argv[i], "--maps-layouts") && i + 1 < argc)
+            g_MapsLayouts = std::string(argv[++i]);
     }
 
     if (SDL_Init(SDL_INIT_TIMER) < 0)

--- a/OrionUO/OrionUO.cpp
+++ b/OrionUO/OrionUO.cpp
@@ -203,6 +203,11 @@ void COrion::ParseCommandLine() // FIXME: move this out
                     string("|") +
                     DecodeArgumentString(strings[1].c_str(), (int)strings[1].length());
         }
+        else if (str == "maps_layouts")
+        {
+            if (haveParam)
+                g_MapsLayouts = strings[1];
+        }
         else if (str == "nowarnings")
             g_ShowWarnings = false;
 #if !USE_ORIONDLL


### PR DESCRIPTION
## Summary
- add `maps_layouts` argument handling in `COrion::ParseCommandLine`
- parse `--maps-layouts` in `main`

## Testing
- `clang-format-14 -style=file -i OrionUO/OrionUO.cpp OrionUO/OrionMain.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6855a5738410832fb312749927227173