### PR TITLE
Support up to 15 maps

### DIFF
--- a/OrionUO/Managers/FileManager.cpp
+++ b/OrionUO/Managers/FileManager.cpp
@@ -125,7 +125,7 @@ bool CFileManager::Load()
     m_SpeechMul.Load(g_App.UOFilesPath("speech.mul"));
     m_LangcodeIff.Load(g_App.UOFilesPath("Langcode.iff"));
 
-    IFOR (i, 0, 6)
+    IFOR (i, 0, MAX_MAPS_COUNT)
     {
         if (i > 1)
         {
@@ -245,7 +245,7 @@ bool CFileManager::LoadWithUOP()
     m_SpeechMul.Load(g_App.UOFilesPath("speech.mul"));
     m_LangcodeIff.Load(g_App.UOFilesPath("Langcode.iff"));
 
-    IFOR (i, 0, 6)
+    IFOR (i, 0, MAX_MAPS_COUNT)
     {
         if (i > 1)
         {
@@ -321,7 +321,7 @@ void CFileManager::Unload()
 
     m_LangcodeIff.Unload();
 
-    IFOR (i, 0, 6)
+    IFOR (i, 0, MAX_MAPS_COUNT)
     {
         m_AnimIdx[i].Unload();
         m_AnimMul[i].close();
@@ -370,7 +370,7 @@ void CFileManager::SendFilesInfo()
         CPluginPacketFileInfo(OFI_HUES_MUL, (uint64)m_HuesMul.Start, (uint64)m_HuesMul.Size)
             .SendToPlugin();
 
-    IFOR (i, 0, 6)
+    IFOR (i, 0, MAX_MAPS_COUNT)
     {
         if (m_MapMul[i].Start != NULL)
             CPluginPacketFileInfo(

--- a/OrionUO/Managers/FileManager.h
+++ b/OrionUO/Managers/FileManager.h
@@ -67,33 +67,33 @@ public:
     AutoResetEvent m_AutoResetEvent;
 
     //!Адреса файлов в памяти
-    WISP_FILE::CMappedFile m_AnimIdx[6];
+    WISP_FILE::CMappedFile m_AnimIdx[MAX_MAPS_COUNT];
     WISP_FILE::CMappedFile m_ArtIdx;
     WISP_FILE::CMappedFile m_GumpIdx;
     WISP_FILE::CMappedFile m_LightIdx;
     WISP_FILE::CMappedFile m_MultiIdx;
     WISP_FILE::CMappedFile m_SkillsIdx;
     WISP_FILE::CMappedFile m_SoundIdx;
-    WISP_FILE::CMappedFile m_StaticIdx[6];
+    WISP_FILE::CMappedFile m_StaticIdx[MAX_MAPS_COUNT];
     WISP_FILE::CMappedFile m_TextureIdx;
 
-    std::fstream m_AnimMul[6];
+    std::fstream m_AnimMul[MAX_MAPS_COUNT];
     WISP_FILE::CMappedFile m_AnimdataMul;
     WISP_FILE::CMappedFile m_ArtMul;
     WISP_FILE::CMappedFile m_HuesMul;
     WISP_FILE::CMappedFile m_GumpMul;
     WISP_FILE::CMappedFile m_LightMul;
-    WISP_FILE::CMappedFile m_MapMul[6];
+    WISP_FILE::CMappedFile m_MapMul[MAX_MAPS_COUNT];
     WISP_FILE::CMappedFile m_MultiMul;
     WISP_FILE::CMappedFile m_RadarcolMul;
     WISP_FILE::CMappedFile m_SkillsMul;
     WISP_FILE::CMappedFile m_SoundMul;
-    WISP_FILE::CMappedFile m_StaticMul[6];
+    WISP_FILE::CMappedFile m_StaticMul[MAX_MAPS_COUNT];
     WISP_FILE::CMappedFile m_TextureMul;
     WISP_FILE::CMappedFile m_TiledataMul;
     WISP_FILE::CMappedFile m_UnifontMul[20];
     WISP_FILE::CMappedFile m_VerdataMul;
-    WISP_FILE::CMappedFile m_FacetMul[6];
+    WISP_FILE::CMappedFile m_FacetMul[MAX_MAPS_COUNT];
 
     WISP_FILE::CMappedFile m_MultiMap;
     WISP_FILE::CMappedFile m_SpeechMul;
@@ -105,18 +105,18 @@ public:
     CUopMappedFile m_SoundLegacyMUL;
     CUopMappedFile m_Tileart;
     CUopMappedFile m_MainMisc;
-    CUopMappedFile m_MapUOP[6];
-    CUopMappedFile m_MapXUOP[6];
+    CUopMappedFile m_MapUOP[MAX_MAPS_COUNT];
+    CUopMappedFile m_MapXUOP[MAX_MAPS_COUNT];
     CUopMappedFile m_AnimationSequence;
     CUopMappedFile m_MultiCollection;
 
     //Map patches
-    WISP_FILE::CMappedFile m_MapDifl[6];
-    WISP_FILE::CMappedFile m_MapDif[6];
+    WISP_FILE::CMappedFile m_MapDifl[MAX_MAPS_COUNT];
+    WISP_FILE::CMappedFile m_MapDif[MAX_MAPS_COUNT];
 
-    WISP_FILE::CMappedFile m_StaDifl[6];
-    WISP_FILE::CMappedFile m_StaDifi[6];
-    WISP_FILE::CMappedFile m_StaDif[6];
+    WISP_FILE::CMappedFile m_StaDifl[MAX_MAPS_COUNT];
+    WISP_FILE::CMappedFile m_StaDifi[MAX_MAPS_COUNT];
+    WISP_FILE::CMappedFile m_StaDif[MAX_MAPS_COUNT];
 
     bool Load();
     bool LoadWithUOP();

--- a/OrionUO/OrionUO.cpp
+++ b/OrionUO/OrionUO.cpp
@@ -421,7 +421,7 @@ bool COrion::Install()
 
     g_CreateCharacterManager.Init();
 
-    IFOR (i, 0, 6)
+    IFOR (i, 0, MAX_MAPS_COUNT)
         g_AnimationManager.Init(
             (int)i,
             (size_t)g_FileManager.m_AnimIdx[i].Start,
@@ -535,7 +535,7 @@ void COrion::Uninstall()
 
     g_AuraTexture.Clear();
 
-    IFOR (i, 0, 6)
+    IFOR (i, 0, MAX_MAPS_COUNT)
         g_MapTexture[i].Clear();
 
     IFOR (i, 0, 2)
@@ -5950,7 +5950,7 @@ void COrion::AddJournalMessage(CTextData *msg, const string &name)
 void COrion::ChangeMap(uchar newmap)
 {
     WISPFUN_DEBUG("c194_f102");
-    if (newmap < 0 || newmap > 5)
+    if (newmap < 0 || newmap >= MAX_MAPS_COUNT)
         newmap = 0;
 
     if (g_CurrentMap != newmap)


### PR DESCRIPTION
## Summary
- size map file arrays with `MAX_MAPS_COUNT`
- iterate through `MAX_MAPS_COUNT` when loading/unloading map files
- clear textures and init animations for all supported maps
- allow `ChangeMap` to check against `MAX_MAPS_COUNT`

## Testing
- `cmake ..` *(fails: Could NOT find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_6855bd0762cc832fa8be55572a778a90