### PR TITLE
Add map count override for Client.cuo generation

### DIFF
--- a/OrionUO/Crypt/CryptEntry.h
+++ b/OrionUO/Crypt/CryptEntry.h
@@ -2,4 +2,5 @@
 #if !USE_ORIONDLL
 size_t GetPluginsCount();
 void CryptInstallNew(uchar *address, size_t size, uchar *result, size_t &resultSize);
+void SetCryptForceMapsCount(int count);
 #endif

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ ninja OrionUO_unity -j8
 $ ./OrionUO/unity/OrionUO
 ```
 
-  > You'll need a `Client.cuo` and a `uo_debug.cfg` in the working directory. Inside `uo_debug.cfg` you can add a line `CustomPath=/path/to/uo/data`, so Orion will be able to find your original client data files.
+  > You'll need a `Client.cuo` and a `uo_debug.cfg` in the working directory. Inside `uo_debug.cfg` you can add a line `CustomPath=/path/to/uo/data`, so Orion will be able to find your original client data files. If you want to generate a `Client.cuo` that supports up to 127 maps, set the environment variable `ORION_FORCE_MAPS_COUNT=127` before running the configuration tool.
 
 
 


### PR DESCRIPTION
## Summary
- allow overriding map count via `ORION_FORCE_MAPS_COUNT`
- document the new environment variable in the README

## Testing
- `clang-format -i OrionUO/Crypt/CryptEntry.cpp OrionUO/Crypt/CryptEntry.h` *(fails: Invalid argument)*
- `cmake ..` *(fails: Could NOT find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_685625b15ba0832faa362f2e77ca6c39